### PR TITLE
Enable TestFullOrcReader on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,7 @@ jobs:
             !:trino-cassandra,
             !:trino-clickhouse,
             !:trino-hive,
+            !:trino-orc,
             !:trino-elasticsearch,
             !:trino-mongodb,
             !:trino-kafka,
@@ -384,6 +385,7 @@ jobs:
             - { modules: plugin/trino-hive, profile: test-parquet }
             - { modules: plugin/trino-hive, profile: test-failure-recovery }
             - { modules: plugin/trino-hive, profile: test-fault-tolerant-execution }
+            - { modules: lib/trino-orc }
             - { modules: plugin/trino-elasticsearch }
             - { modules: plugin/trino-elasticsearch, profile: test-stats }
             - { modules: plugin/trino-mongodb }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,7 @@ jobs:
             - { modules: plugin/trino-hive, profile: test-failure-recovery }
             - { modules: plugin/trino-hive, profile: test-fault-tolerant-execution }
             - { modules: lib/trino-orc }
+            - { modules: lib/trino-orc, profile: test-full-orc-reader }
             - { modules: plugin/trino-elasticsearch }
             - { modules: plugin/trino-elasticsearch, profile: test-stats }
             - { modules: plugin/trino-mongodb }

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -179,4 +179,39 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- TestFullOrcReader takes a long time and might produce no output leading to Travis aborting the build -->
+                        <!-- TODO https://github.com/trinodb/trino/issues/612 run TestFullOrcReader on CI -->
+                        <exclude>**/TestFullOrcReader.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>test-full-orc-reader</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestFullOrcReader.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -179,20 +179,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <!-- TestFullOrcReader takes a long time and might produce no output leading to Travis aborting the build -->
-                        <!-- TODO https://github.com/trinodb/trino/issues/612 run TestFullOrcReader on CI -->
-                        <exclude>**/TestFullOrcReader.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestFullOrcReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestFullOrcReader.java
@@ -13,9 +13,6 @@
  */
 package io.trino.orc;
 
-import org.testng.annotations.Test;
-
-@Test(groups = "ci")
 public class TestFullOrcReader
         extends AbstractTestOrcReader
 {


### PR DESCRIPTION
This test used to time-out on TravisCI and wasn't enabled on GHA. To
prevent chances of regression this is being enabled on CI as separate
job.